### PR TITLE
Allow psr/log v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3 || ^7.3",
-    "psr/log": "^1.1"
+    "psr/log": "^1.1 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Some new php 8.0+ libraries use psr/log version 3, so allow it to be used as well.