### PR TITLE
PSR-17 and PSR-18 compability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,4 @@
 /.gitlab-ci.yml export-ignore
 /.php-cs-fixer.dist.php export-ignore
 /phpstan.neon export-ignore
-/Tests/ export-ignore
+/tests/ export-ignore

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3 || ^7.3",
-    "psr/log": "^1.1 || ^3.0"
+    "psr/log": "^1.1 || ^3.0",
+    "psr/http-client": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
     "phpstan/phpstan": "^1.2",
     "friendsofphp/php-cs-fixer": "^3.3",
-    "phpro/grumphp": "^1.5"
+    "phpro/grumphp": "^1.5",
+    "guzzlehttp/guzzle": "^6.3 || ^7.3"
   },
   "autoload": {
     "psr-4": {
@@ -41,5 +42,8 @@
     "psr-4": {
       "Fairway\\CantoSaasApi\\Tests\\": "tests"
     }
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "Recommended default implementation of the psr-18 http-client interface."
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "psr/log": "^1.1 || ^3.0",
-    "psr/http-client": "^1.0"
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-json": "*",
     "psr/log": "^1.1 || ^3.0",
     "psr/http-client": "^1.0",
-    "psr/http-factory": "^1.1"
+    "psr/http-factory": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,7 +26,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class Client
+class Client implements RequestFactoryInterface
 {
     protected const API_VERSION = 'v1';
     protected const API_ROUTE = 'https://%s.%s/api';

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,10 +15,11 @@ use Fairway\CantoSaasApi\Endpoint\Asset;
 use Fairway\CantoSaasApi\Endpoint\Authorization\OAuth2;
 use Fairway\CantoSaasApi\Endpoint\LibraryTree;
 use Fairway\CantoSaasApi\Endpoint\Upload;
+use Fairway\CantoSaasApi\Exception\HttpClientException;
 use Fairway\CantoSaasApi\Helper\MdcUrlHelper;
 use Fairway\CantoSaasApi\Http\Authorization\OAuth2Request;
 use Fairway\CantoSaasApi\Http\Authorization\OAuth2Response;
-use GuzzleHttp\ClientInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -142,13 +143,17 @@ class Client
 
     protected function buildHttpClient(): ClientInterface
     {
-        return new \GuzzleHttp\Client([
-            'allow_redirects' => true,
-            'connect_timeout' => (int)$this->options->getHttpClientOptions()['timeout'],
-            'debug' => (bool)$this->options->getHttpClientOptions()['debug'],
-            'headers' => [
-                'userAgent' => $this->options->getHttpClientOptions()['userAgent'],
-            ],
-        ]);
+        if (class_exists('\GuzzleHttp\Client')) {
+            return new \GuzzleHttp\Client([
+                'allow_redirects' => true,
+                'connect_timeout' => (int)$this->options->getHttpClientOptions()['timeout'],
+                'debug' => (bool)$this->options->getHttpClientOptions()['debug'],
+                'headers' => [
+                    'userAgent' => $this->options->getHttpClientOptions()['userAgent'],
+                ],
+            ]);
+        }
+
+        throw HttpClientException::noDefaultHttpClient();
     }
 }

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Fairway\CantoSaasApi;
 
-use GuzzleHttp\ClientInterface;
 use InvalidArgumentException;
 use JetBrains\PhpStorm\ArrayShape;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -14,6 +14,7 @@ namespace Fairway\CantoSaasApi;
 use InvalidArgumentException;
 use JetBrains\PhpStorm\ArrayShape;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -36,6 +37,7 @@ class ClientOptions
             'timeout' => 'int',
             'userAgent' => 'string',
         ],
+        'httpRequestFactory' => RequestFactoryInterface::class,
         'logger' => LoggerInterface::class
     ];
 
@@ -58,6 +60,8 @@ class ClientOptions
     private ?ClientInterface $httpClient;
 
     private array $httpClientOptions;
+
+    private ?RequestFactoryInterface $httpRequestFactory;
 
     private ?LoggerInterface $logger;
 
@@ -83,6 +87,7 @@ class ClientOptions
             ],
             $options['httpClientOptions'] ?? []
         );
+        $this->httpRequestFactory = $options['httpRequestFactory'] ?? null;
         $this->logger = $options['logger'] ?? null;
         $this->mdcAwsAccountId = $options['mdcAwsAccountId'] ?? '';
         $this->mdcDomainName = $options['mdcDomainName'] ?? '';
@@ -122,6 +127,11 @@ class ClientOptions
     public function getHttpClientOptions(): array
     {
         return $this->httpClientOptions;
+    }
+
+    public function getHttpRequestFactory(): ?RequestFactoryInterface
+    {
+        return $this->httpRequestFactory;
     }
 
     public function getMdcDomainName(): string

--- a/src/Endpoint/AbstractEndpoint.php
+++ b/src/Endpoint/AbstractEndpoint.php
@@ -56,8 +56,8 @@ abstract class AbstractEndpoint
         }
 
         try {
-            $response = $this->client->getHttpClient()->send($request, $options);
-        } catch (RuntimeException $e) {
+            $response = $this->client->getHttpClient()->sendRequest($request);
+        } catch (\Throwable $e) {
             /*
              * API seems to respond with 404 when no authentication token is given but needed.
              * When token is given but invalid, API responds with 401.

--- a/src/Endpoint/Asset.php
+++ b/src/Endpoint/Asset.php
@@ -35,7 +35,6 @@ use Fairway\CantoSaasApi\Http\Asset\SuccessResponse;
 use Fairway\CantoSaasApi\Http\EmptyResponse;
 use Fairway\CantoSaasApi\Http\InvalidResponseException;
 use Fairway\CantoSaasApi\Http\RequestInterface;
-use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
 final class Asset extends AbstractEndpoint
@@ -96,7 +95,7 @@ final class Asset extends AbstractEndpoint
      */
     public function getAuthorizedUrlContent(string $uri, string $method = RequestInterface::GET): ResponseInterface
     {
-        $httpRequest = new Request($method, $uri);
+        $httpRequest = $this->getClient()->createRequest($method, $uri);
         return $this->getResponseWithHttpRequest($httpRequest);
     }
 

--- a/src/Endpoint/Authorization/OAuth2.php
+++ b/src/Endpoint/Authorization/OAuth2.php
@@ -16,7 +16,6 @@ use Fairway\CantoSaasApi\Http\Authorization\OAuth2Request;
 use Fairway\CantoSaasApi\Http\Authorization\OAuth2Response;
 use Fairway\CantoSaasApi\Http\RequestInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 
 final class OAuth2 extends AbstractEndpoint
@@ -28,7 +27,7 @@ final class OAuth2 extends AbstractEndpoint
     public function obtainAccessToken(OAuth2Request $request): OAuth2Response
     {
         $uri = $this->buildRequestUrl($request);
-        $httpRequest = new Request($request->getMethod(), $uri);
+        $httpRequest = $this->getClient()->createRequest($request->getMethod(), $uri);
 
         try {
             $response = $this->sendRequest($httpRequest);

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Fairway\CantoSaasApi\Exception;
+
+
+class HttpClientException extends \RuntimeException
+{
+    public static function noDefaultHttpClient(): self
+    {
+        return new self("No default implementation of the \\Psr\\Http\\Client\\ClientInterface found. Install 'guzzlehttp/guzzle' via composer or provide a custom PSR-18 client via ClientOptions['httpClient‘].");
+    }
+}

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -1,13 +1,25 @@
 <?php
+
 declare(strict_types=1);
 
-namespace Fairway\CantoSaasApi\Exception;
+/*
+ * This file is part of the "fairway_canto_saas_api" library by eCentral GmbH.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
 
+namespace Fairway\CantoSaasApi\Exception;
 
 class HttpClientException extends \RuntimeException
 {
     public static function noDefaultHttpClient(): self
     {
         return new self("No default implementation of the \\Psr\\Http\\Client\\ClientInterface found. Install 'guzzlehttp/guzzle' via composer or provide a custom PSR-18 client via ClientOptions['httpClient‘].");
+    }
+
+    public static function noDefaultHttpRequestFactory(): self
+    {
+        return new self("No default implementation of the \\Psr\\Http\\Message\\RequestFactoryInterface found. Install 'guzzlehttp/guzzle' via composer or provide a custom PSR-17 http-factory via ClientOptions['httpRequestFactory‘].");
     }
 }

--- a/src/Http/LibraryTree/GetTreeResponse.php
+++ b/src/Http/LibraryTree/GetTreeResponse.php
@@ -31,8 +31,8 @@ class GetTreeResponse extends Response
         $responseData = $this->parseResponse($response);
 
         $this->results = $responseData['results'] ?? [];
-        $this->sortBy = $responseData['sortBy'];
-        $this->sortDirection = $responseData['sortDirection'];
+        $this->sortBy = $responseData['sortBy'] ?? '';
+        $this->sortDirection = $responseData['sortDirection'] ?? '';
     }
 
     public function getResults(): array

--- a/src/Http/LibraryTree/SearchFolderRequest.php
+++ b/src/Http/LibraryTree/SearchFolderRequest.php
@@ -24,7 +24,7 @@ class SearchFolderRequest extends Request
     public const SORT_BY_SIZE = 'size';
     public const ORIENTATION_LANDSCAPE = 'landscape';
     public const ORIENTATION_PORTRAIT = 'portrait';
-    public const ORIENTATION_SQUARE= 'square';
+    public const ORIENTATION_SQUARE = 'square';
 
     protected string $folderId;
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -11,10 +11,9 @@ declare(strict_types=1);
 
 namespace Fairway\CantoSaasApi\Http;
 
-use function json_decode;
 use JsonException;
-
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use function json_decode;
 
 abstract class Response implements ResponseInterface
 {

--- a/tests/ClientOptionsTest.php
+++ b/tests/ClientOptionsTest.php
@@ -14,6 +14,7 @@ namespace Fairway\CantoSaasApi\Tests;
 use Fairway\CantoSaasApi\ClientOptions;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\NullLogger;
 
 class ClientOptionsTest extends TestCase
@@ -116,7 +117,7 @@ class ClientOptionsTest extends TestCase
             'appSecret' => 'not-empty',
             'httpClient' => new Client(),
         ]);
-        self::assertInstanceOf(Client::class, $options->getHttpClient());
+        self::assertInstanceOf(ClientInterface::class, $options->getHttpClient());
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,8 +13,8 @@ namespace Fairway\CantoSaasApi\Tests;
 
 use Fairway\CantoSaasApi\Client;
 use Fairway\CantoSaasApi\ClientOptions;
-use GuzzleHttp\ClientInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,8 +13,11 @@ namespace Fairway\CantoSaasApi\Tests;
 
 use Fairway\CantoSaasApi\Client;
 use Fairway\CantoSaasApi\ClientOptions;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -34,6 +37,7 @@ class ClientTest extends TestCase
 
         self::assertInstanceOf(ClientInterface::class, $client->getHttpClient());
         self::assertInstanceOf(LoggerInterface::class, $client->getLogger());
+        self::assertInstanceOf(RequestInterface::class, $client->createRequest('GET', 'https://example.com'));
     }
 
     /**
@@ -43,10 +47,11 @@ class ClientTest extends TestCase
     {
         $clientOptionsMock = $this->getMockBuilder(ClientOptions::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getHttpClient', 'getLogger'])
+            ->onlyMethods(['getHttpClient', 'getLogger', 'getHttpRequestFactory'])
             ->getMock();
         $clientOptionsMock->method('getHttpClient')->willReturn(new \GuzzleHttp\Client());
         $clientOptionsMock->method('getLogger')->willReturn(null);
+        $clientOptionsMock->method('getHttpRequestFactory')->willReturn(null);
         $client = new Client($clientOptionsMock);
 
         self::assertInstanceOf(\GuzzleHttp\Client::class, $client->getHttpClient());
@@ -59,7 +64,7 @@ class ClientTest extends TestCase
     {
         $clientOptionsMock = $this->getMockBuilder(ClientOptions::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getHttpClient', 'getHttpClientOptions', 'getLogger'])
+            ->onlyMethods(['getHttpClient', 'getHttpClientOptions', 'getLogger', 'getHttpRequestFactory'])
             ->getMock();
         $clientOptionsMock->method('getHttpClient')->willReturn(null);
         $clientOptionsMock->method('getHttpClientOptions')->willReturn([
@@ -68,8 +73,47 @@ class ClientTest extends TestCase
             'userAgent' => 'test',
         ]);
         $clientOptionsMock->method('getLogger')->willReturn(new NullLogger());
+        $clientOptionsMock->method('getHttpRequestFactory')->willReturn(null);
         $client = new Client($clientOptionsMock);
 
         self::assertInstanceOf(NullLogger::class, $client->getLogger());
+    }
+
+    /**
+     * @test
+     */
+    public function createRequestFromDefaultRequestFactory(): void
+    {
+        $request = new Request('GET', 'https://example.com');
+        $requestFactory = new class ($request) implements RequestFactoryInterface {
+            public Request $request;
+
+            public function __construct(Request $request)
+            {
+                $this->request = $request;
+            }
+
+            public function createRequest(string $method, $uri): RequestInterface
+            {
+                return $this->request;
+            }
+        };
+        $clientOptionsMock = $this->getMockBuilder(ClientOptions::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getHttpClient', 'getHttpClientOptions', 'getLogger', 'getHttpRequestFactory'])
+            ->getMock();
+        $clientOptionsMock->method('getHttpClient')->willReturn(null);
+        $clientOptionsMock->method('getHttpClientOptions')->willReturn([
+            'debug' => false,
+            'timeout' => 10,
+            'userAgent' => 'test',
+        ]);
+        $clientOptionsMock->method('getLogger')->willReturn(null);
+        $clientOptionsMock->method('getHttpRequestFactory')->willReturn($requestFactory);
+
+        $client = new Client($clientOptionsMock);
+        $requestFromFactory = $client->createRequest('GET-IGNORE-ME', 'https://ignore-me.com');
+
+        self::assertSame($requestFromFactory, $request);
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -35,6 +35,7 @@ class ClientTest extends TestCase
         ]);
         $client = new Client($options);
 
+        self::assertInstanceOf(RequestFactoryInterface::class, $client);
         self::assertInstanceOf(ClientInterface::class, $client->getHttpClient());
         self::assertInstanceOf(LoggerInterface::class, $client->getLogger());
         self::assertInstanceOf(RequestInterface::class, $client->createRequest('GET', 'https://example.com'));

--- a/tests/Endpoint/Authorization/OAuth2Test.php
+++ b/tests/Endpoint/Authorization/OAuth2Test.php
@@ -23,7 +23,6 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 
 class OAuth2Test extends TestCase
 {
@@ -76,29 +75,19 @@ class OAuth2Test extends TestCase
         $oAuth2->obtainAccessToken($oAuthRequest);
     }
 
-    protected function buildClientMock(MockHandler $mockHandler): MockObject
+    protected function buildClientMock(MockHandler $mockHandler): Client
     {
-        $optionsMock = $this->getMockBuilder(ClientOptions::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getCantoName', 'getCantoDomain'])
-            ->getMock();
-        $optionsMock->method('getCantoName')->willReturn('test');
-        $optionsMock->method('getCantoDomain')->willReturn('canto.com');
-
         $httpClient = new HttpClient([
             'handler' => HandlerStack::create($mockHandler),
         ]);
 
-        $clientMock = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHttpClient', 'getLogger', 'getOptions', 'getAccessToken'])
-            ->getMock();
-        $clientMock->method('getHttpClient')->willReturn($httpClient);
-        $clientMock->method('getLogger')->willReturn(new NullLogger());
-        $clientMock->method('getOptions')->willReturn($optionsMock);
-        $clientMock->method('getAccessToken')->willReturn(null);
-
-        return $clientMock;
+        return new Client(new ClientOptions([
+            'cantoName' => 'test',
+            'cantoDomain' => 'canto.com',
+            'appId' => 'test',
+            'appSecret' => 'test',
+            'httpClient' => $httpClient,
+        ]));
     }
 
     protected function buildRequestMock(): MockObject


### PR DESCRIPTION
As we are goin to use this library in our Symfony full-stack project, but we don't want to require an additional http-client, I've abstracted everything tightly coupled to guzzle out and replaced it with PSR-18 ClientInterfaces and PSR-17 RequestFactoryInterfaces.

This also adds a BC Break, since the Client now also implements the `Psr\Http\Message\RequestFactoryInterface`, so `Psr\Http\Message\RequestInterface` compatible requests can be created via the Client itself.

The `RequestFactoryInterface` to be used can be passed via the ClientOptions `httpRequestFactory` key and defaults to an anonymous implementation, returning a `\GuzzleHttp\Psr7\Request`, if guzzle is installed.

If guzzle is not installed and you forget to pass `httpClient` and `httpRequestFactory` to the ClientOptions, it will throw dedicated HttpClientExceptions.

I moved `guzzlehttp/guzzle` to `require-dev`, so it can be used for testing, but suggest it to be installed as a default http-client solution.